### PR TITLE
dataservice: only build for sony platform

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,1 +1,5 @@
+ifneq ($(filter yukon rhine shinano kanuti kitakami,$(PRODUCT_PLATFORM)),)
+
 include $(call all-subdir-makefiles)
+
+endif


### PR DESCRIPTION
This solves the crash of AOSP device builds when the sony repos are present as the AOSP devices like shamu provide their own dataservices.
