### PR TITLE
dataservices: remove CAF conditional

### DIFF
--- a/rmnetctl/src/Android.mk
+++ b/rmnetctl/src/Android.mk
@@ -10,13 +10,10 @@ LOCAL_CFLAGS := -Wall -Werror
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../inc
 LOCAL_C_INCLUDES += $(LOCAL_PATH)
 
-ifeq ($(call is-vendor-board-platform,QCOM),true)
 ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
     LOCAL_ADDITIONAL_DEPENDENCIES := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
     LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 endif
-endif
-
 
 LOCAL_MODULE := librmnetctl
 LOCAL_MODULE_TAGS := optional

--- a/sockev/src/Android.mk
+++ b/sockev/src/Android.mk
@@ -5,13 +5,10 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := sockev_cli.c
 LOCAL_CFLAGS := -Wall -Werror
 
-ifeq ($(call is-vendor-board-platform,QCOM),true)
 ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
     LOCAL_ADDITIONAL_DEPENDENCIES := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
     LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 endif
-endif
-
 
 LOCAL_MODULE := sockev
 LOCAL_MODULE_TAGS := optional


### PR DESCRIPTION
TARGET_COMPILE_WITH_MSM_KERNEL := true is allowed to be set by user and use Kernel-headers but
call is-vendor-board-platform,QCOM is unknown by AOSP system ... remove this one in favour of kernel headers flag

Signed-off-by: David Viteri davidteri91@gmail.com
